### PR TITLE
Fix Illegal back reference error

### DIFF
--- a/syntax/koka.vim
+++ b/syntax/koka.vim
@@ -58,8 +58,8 @@ syn match kokaAnyID /\<\([a-z]\w\?\(-\?[a-zA-Z]\w*\)*['?]*-\?\)/
 
 syn match kokaUnderscore "_"
 
-syn match kokaChar /\('\(\\\([nrt\\"']\|x\x\{2\}\|u\x\{4\}\|U\x\4\)\|[^\\']\)'\)/
-syn match kokaChar0 /\(\\\([nrt\\"']\|x\x\{2\}\|u\x\{4\}\|U\x\4\)\|[^\\']\)/
+syn match kokaChar /\('\(\\\([nrt\\"']\|x\x\{2\}\|u\x\{4\}\|U\x\{4\}\)\|[^\\']\)'\)/
+syn match kokaChar0 /\(\\\([nrt\\"']\|x\x\{2\}\|u\x\{4\}\|U\x\{4\}\)\|[^\\']\)/
 syn region  kokaString0 start=+"+ end=+"+ end=+$+
 syn region  kokaRawString start=+@"+ end=+"+ end=+$+
 syn cluster kokaString contains=kokaString0,kokaRawString,kokaChar


### PR DESCRIPTION
### Environment
- vim-koka (master)
- MacVim 8.1 (patch version 280)

### Error

```
"Work/koka/sample/say.kk" [dos] 24L, 360C
[unite.vim] /Users/kodama/Work/dotvim/bundle/vim-koka/syntax/koka.vim, line 61
[unite.vim] Vim(syntax):E65: Illegal back reference
[unite.vim] Error occurred while executing "open" action!
Press ENTER or type command to continue
```

### Fix

"\4" is interpreted as back reference and adding curly brackets.